### PR TITLE
Make Update MPC instruction work with Orbitals plugin

### DIFF
--- a/Utility/MPCDownloader.cs
+++ b/Utility/MPCDownloader.cs
@@ -58,7 +58,7 @@ namespace NINA.RBarbera.Plugin.NeocpHelper.Utility {
             var request = (HttpWebRequest)WebRequest.Create("https://cgi.minorplanetcenter.net/cgi-bin/mpeph2.cgi");
 
             // Mangle names so they are accepted by MPC API
-            var Type = "";
+            var Type = "unknown";
             if (obj.IndexOf("(") > 1) {
                 Type = "comet";
                 obj = obj.Replace(" ", "+");
@@ -68,7 +68,7 @@ namespace NINA.RBarbera.Plugin.NeocpHelper.Utility {
                 Type = "unnumbered body";
                 obj = obj.Replace(" ", "+");
             }
-            else {
+            else if (obj.IndexOf("(") > 1) {
                 Type = "numbered body";
                 obj = obj.Replace("/", "+");
             }
@@ -165,3 +165,4 @@ namespace NINA.RBarbera.Plugin.NeocpHelper.Utility {
         
     }
 }
+

--- a/Utility/MPCDownloader.cs
+++ b/Utility/MPCDownloader.cs
@@ -1,4 +1,4 @@
-﻿using NINA.Core.Utility;
+using NINA.Core.Utility;
 using NINA.Profile.Interfaces;
 using NINA.RBarbera.Plugin.NeocpHelper.Models;
 using NINA.RBarbera.Plugin.NEOCPHelper.Utility;
@@ -57,8 +57,25 @@ namespace NINA.RBarbera.Plugin.NeocpHelper.Utility {
         public static List<NEOCPEphemeride> GetMPCEphemerides(string obj, IAstrometrySettings astrometrySettings, NeocpHelper neocpHelper) {
             var request = (HttpWebRequest)WebRequest.Create("https://cgi.minorplanetcenter.net/cgi-bin/mpeph2.cgi");
 
+            // Mangle names so they are accepted by MPC API
+            var Type = "";
+            if (obj.IndexOf("(") > 1) {
+                Type = "comet";
+                obj = obj.Replace(" ", "+");
+                obj = obj[..(obj.IndexOf("(") - 1)];
+            }
+            else if (obj.IndexOf(" ") > 1) {
+                Type = "unnumbered body";
+                obj = obj.Replace(" ", "+");
+            }
+            else {
+                Type = "numbered body";
+                obj = obj.Replace("/", "+");
+            }
+            Logger.Info("Object " + obj + " identified as " + Type);
+
             var query = MPCQueryString(astrometrySettings, obj, neocpHelper);
-            var data = Encoding.ASCII.GetBytes(query);
+            var data = Encoding.UTF8.GetBytes(query);
 
             request.Method = "POST";
             request.ContentType = "application/x-www-form-urlencoded";

--- a/Utility/MPCDownloader.cs
+++ b/Utility/MPCDownloader.cs
@@ -68,7 +68,7 @@ namespace NINA.RBarbera.Plugin.NeocpHelper.Utility {
                 Type = "unnumbered body";
                 obj = obj.Replace(" ", "+");
             }
-            else if (obj.IndexOf("(") > 1) {
+            else if (obj.IndexOf("/") > 1) {
                 Type = "numbered body";
                 obj = obj.Replace("/", "+");
             }
@@ -165,4 +165,5 @@ namespace NINA.RBarbera.Plugin.NeocpHelper.Utility {
         
     }
 }
+
 


### PR DESCRIPTION
Functional extension - target names generated by Orbitals (comets, unnumbered, numbered bodies) are now accepted by MPC, so the ephemerides are now updated without any manual modification.